### PR TITLE
Add proxy functionality

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,4 +1,5 @@
+/opt/splunk/bin/splunk cmd python3 -m pip install wheel
 /opt/splunk/bin/splunk cmd python3 -m pip install --upgrade -t src/main/resources/splunk/lib -r src/main/resources/splunk/lib/requirements.txt --no-dependencies
-yarn install
+yarn install --ignore-engines
 yarn run build
 yarn run link:app

--- a/.devcontainer/start.sh
+++ b/.devcontainer/start.sh
@@ -1,2 +1,4 @@
+#git stash
 git pull --rebase
+#git stash pop
 /opt/splunk/bin/splunk start --accept-license --answer-yes --no-prompt --seed-passwd devcontainer

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ functional-temp
 splunktional-temp
 src/main/resources/splunk/lib/*
 !src/main/resources/splunk/lib/requirements.txt
+yarn.lock

--- a/src/main/resources/splunk/README/inputs.conf.spec
+++ b/src/main/resources/splunk/README/inputs.conf.spec
@@ -1,3 +1,8 @@
 [hibp_domainsearch://default]
-interval = <seconds>
+interval = <integer>
 index = <string>
+authenticationEnabled = <boolean>
+proxyPort = <integer>
+proxyServer = <string>
+proxyEnabled = <boolean>
+proxyUsername = <string>

--- a/src/main/resources/splunk/README/inputs.conf.spec
+++ b/src/main/resources/splunk/README/inputs.conf.spec
@@ -1,8 +1,7 @@
 [hibp_domainsearch://default]
 interval = <integer>
 index = <string>
-authenticationEnabled = <boolean>
 proxyPort = <integer>
 proxyServer = <string>
 proxyEnabled = <boolean>
-proxyUsername = <string>
+proxyUser = <string>

--- a/src/main/resources/splunk/bin/api.py
+++ b/src/main/resources/splunk/bin/api.py
@@ -9,64 +9,67 @@ from urllib.parse import quote_plus
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "lib"))
 import splunklib.client as client
 
+
 class index(PersistentServerConnectionApplication):
     APP_NAME = "hibp"
 
     def __init__(self, command_line, command_arg, logger=None):
         super(PersistentServerConnectionApplication, self).__init__()
-        logging.basicConfig(level=logging.INFO) 
+        logging.basicConfig(level=logging.INFO)
         self.logger = logger
         if self.logger == None:
             self.logger = logging.getLogger(f"splunk.appserver.{self.APP_NAME}")
-            
-    def get_proxy_config(self, config, service):
-        proxyUser=""
-        proxyPass=""
-        proxyHost=config['proxyServer']
-        proxyPort=config['proxyPort']
-        latestPass=0
-        if(int(config['authenticationEnabled']) == 1):
-            proxyUser=config['proxyUsername']
-            for password in service.storage_passwords.list():
-                if(password.content.realm == "hibp-proxy"):
-                    if(int(password.content.username) >= latestPass):
-                        latestPass=int(password.content.username)
-                        proxyPass=password.content.clear_password
-            proxyauth = 'http://{user}:{passw}@{proxy}:{port}'.format(user=quote_plus(proxyUser),
-                                                                      passw=quote_plus(proxyPass),
-                                                                      proxy=proxyHost,
-                                                                      port=proxyPort)
-            return {'http': proxyauth, 'https': proxyauth }
+
+    def get_proxy_config(self, config):
+        if "proxyServer" not in config or "proxyPort" not in config:
+            return {}
+        proxyHost = config["proxyServer"]
+        proxyPort = config["proxyPort"]
+        proxyUser = config.get("proxyUser", "")
+        proxyPass = ""
+        if proxyUser:
+            for password in self.service.storage_passwords.list():
+                if password.content.realm == "hibp-proxy":
+                    proxyPass = password.content.clear_password
+            proxyauth = "http://{user}:{passw}@{proxy}:{port}".format(
+                user=quote_plus(proxyUser),
+                passw=quote_plus(proxyPass),
+                proxy=proxyHost,
+                port=proxyPort,
+            )
+            return {"http": proxyauth, "https": proxyauth}
         else:
-            proxynoauth = 'http://{proxy}:{port}'.format(proxy=proxyHost,
-                                                         port=proxyPort)
-            return {'http': proxynoauth, 'https': proxynoauth }
+            proxynoauth = "http://{proxy}:{port}".format(
+                proxy=proxyHost, port=proxyPort
+            )
+            return {"http": proxynoauth, "https": proxynoauth}
 
     def handle(self, in_string):
         args = json.loads(in_string)
         if args["method"] != "POST":
             return {"payload": "", "status": 504}
-        
-        service = client.connect(token=args['session']['authtoken'], app=self.APP_NAME)
-        inputs_conf = service.confs['inputs']['hibp_domainsearch://default'].content
-        proxyconf = {}
-        if int(inputs_conf['proxyEnabled']) == 1:
-            proxyconf=self.get_proxy_config(inputs_conf, service)
+
+        service = client.connect(token=args["session"]["authtoken"], app=self.APP_NAME)
+        inputs_conf = service.confs["inputs"]["hibp_domainsearch://default"].content
+        proxyconf = self.get_proxy_config(inputs_conf, service)
 
         form = dict(args.get("form", []))
         try:
             APIKEY = form["apikey"]
         except KeyError:
             return {"payload": "No apikey provided", "status": 400}
-        
+
         try:
             ENDPOINT = form["endpoint"]
         except KeyError:
             return {"payload": "No endpoint provided", "status": 400}
 
         try:
-            with requests.get(f"https://haveibeenpwned.com/api/v3/{ENDPOINT}", proxies=proxyconf, headers={"hibp-api-key": APIKEY, "user-agent": "HIBP-Splunk-App"}) as r:
+            with requests.get(
+                f"https://haveibeenpwned.com/api/v3/{ENDPOINT}",
+                proxies=proxyconf,
+                headers={"hibp-api-key": APIKEY, "user-agent": "HIBP-Splunk-App"},
+            ) as r:
                 return {"payload": r.text, "status": r.status_code}
         except Exception as e:
             return {"payload": str(e), "status": 500}
-        

--- a/src/main/resources/splunk/bin/api.py
+++ b/src/main/resources/splunk/bin/api.py
@@ -32,7 +32,6 @@ class index(PersistentServerConnectionApplication):
                     if(int(password.content.username) >= latestPass):
                         latestPass=int(password.content.username)
                         proxyPass=password.content.clear_password
-                        self.logger.info(proxyPass)
             proxyauth = 'http://{user}:{passw}@{proxy}:{port}'.format(user=quote_plus(proxyUser),
                                                                       passw=quote_plus(proxyPass),
                                                                       proxy=proxyHost,

--- a/src/main/resources/splunk/bin/api.py
+++ b/src/main/resources/splunk/bin/api.py
@@ -2,24 +2,59 @@ from splunk.persistconn.application import PersistentServerConnectionApplication
 import json
 import logging
 import requests
+import sys
+import os
+from urllib.parse import quote_plus
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "lib"))
+import splunklib.client as client
 
 class index(PersistentServerConnectionApplication):
     APP_NAME = "hibp"
 
     def __init__(self, command_line, command_arg, logger=None):
+        super(PersistentServerConnectionApplication, self).__init__()
+        logging.basicConfig(level=logging.INFO) 
         self.logger = logger
         if self.logger == None:
             self.logger = logging.getLogger(f"splunk.appserver.{self.APP_NAME}")
-
-        PersistentServerConnectionApplication.__init__(self)
+            
+    def get_proxy_config(self, config, service):
+        proxyUser=""
+        proxyPass=""
+        proxyHost=config['proxyServer']
+        proxyPort=config['proxyPort']
+        latestPass=0
+        if(int(config['authenticationEnabled']) == 1):
+            proxyUser=config['proxyUsername']
+            for password in service.storage_passwords.list():
+                if(password.content.realm == "hibp-proxy"):
+                    if(int(password.content.username) >= latestPass):
+                        latestPass=int(password.content.username)
+                        proxyPass=password.content.clear_password
+                        self.logger.info(proxyPass)
+            proxyauth = 'http://{user}:{passw}@{proxy}:{port}'.format(user=quote_plus(proxyUser),
+                                                                      passw=quote_plus(proxyPass),
+                                                                      proxy=proxyHost,
+                                                                      port=proxyPort)
+            return {'http': proxyauth, 'https': proxyauth }
+        else:
+            proxynoauth = 'http://{proxy}:{port}'.format(proxy=proxyHost,
+                                                         port=proxyPort)
+            return {'http': proxynoauth, 'https': proxynoauth }
 
     def handle(self, in_string):
         args = json.loads(in_string)
         if args["method"] != "POST":
             return {"payload": "", "status": 504}
+        
+        service = client.connect(token=args['session']['authtoken'], app=self.APP_NAME)
+        inputs_conf = service.confs['inputs']['hibp_domainsearch://default'].content
+        proxyconf = {}
+        if int(inputs_conf['proxyEnabled']) == 1:
+            proxyconf=self.get_proxy_config(inputs_conf, service)
 
         form = dict(args.get("form", []))
-
         try:
             APIKEY = form["apikey"]
         except KeyError:
@@ -31,7 +66,7 @@ class index(PersistentServerConnectionApplication):
             return {"payload": "No endpoint provided", "status": 400}
 
         try:
-            with requests.get(f"https://haveibeenpwned.com/api/v3/{ENDPOINT}", headers={"hibp-api-key": APIKEY, "user-agent": "HIBP-Splunk-App"}) as r:
+            with requests.get(f"https://haveibeenpwned.com/api/v3/{ENDPOINT}", proxies=proxyconf, headers={"hibp-api-key": APIKEY, "user-agent": "HIBP-Splunk-App"}) as r:
                 return {"payload": r.text, "status": r.status_code}
         except Exception as e:
             return {"payload": str(e), "status": 500}

--- a/src/main/resources/splunk/default/restmap.conf
+++ b/src/main/resources/splunk/default/restmap.conf
@@ -7,7 +7,7 @@ output_modes = json
 handler = hibp.api
 python.version = python3
 passConf = false
-passSession = false
+passSession = true
 passPayload = false
 
 [script:input]

--- a/src/main/webapp/pages/setup/index.jsx
+++ b/src/main/webapp/pages/setup/index.jsx
@@ -183,6 +183,7 @@ const AddProxy = () => {
     const [proxyPort, setProxyPort] = useState(0);
     const [proxyUsername, setProxyUsername] = useState('');
     const [proxyPassword, setProxyPassword] = useState('');
+    const [proxyEnabled, setProxyEnabled] = useState(false);
     const [authenticationEnabled, setAuthenticationEnabled] = useState(false);
 
     const fetchInit = getDefaultFetchInit();
@@ -209,13 +210,15 @@ const AddProxy = () => {
                     proxyServer,
                     proxyPort,
                     authenticationEnabled,
+                    proxyEnabled,
                     proxyUsername: authenticationEnabled ? proxyUsername : "",
                 })
             } else {
                 postBody = makeBody({
                     proxyServer,
                     proxyPort,
-                    authenticationEnabled
+                    authenticationEnabled,
+                    proxyEnabled
                 })
             }
 
@@ -261,15 +264,31 @@ const AddProxy = () => {
         addProxySettings.reset();
     };
 
-    const handleAuthenticationChange = (event) => {
+    const handleAuthenticationChange = () => {
         setAuthenticationEnabled(prevState => !prevState);
-        console.log('Authentication Enabled:', !authenticationEnabled);
+        addProxySettings.reset();
+    };
+
+    const handleProxyToggleChange = () => {
+        setProxyEnabled(prevState => !prevState);
+        fetch(`${splunkdPath}/servicesNS/nobody/hibp/configs/conf-inputs/hibp_domainsearch%3A%252F%252Fdefault?output_mode=json`, fetchInit).then(
+            (res) =>
+                console.log(res.json())
+        )
         addProxySettings.reset();
     };
 
     return (
         <>
-<ControlGroup labelWidth={WIDTH} label="Proxy Hostname" error={addProxySettings.error}>
+    <ControlGroup labelWidth={WIDTH} label="Enable Proxy">
+    <Switch 
+        selected={proxyEnabled}
+        onClick={handleProxyToggleChange}
+        data-test="switch"
+        appearance="toggle"
+    />
+    </ControlGroup>
+    <ControlGroup labelWidth={WIDTH} label="Proxy Hostname" error={addProxySettings.error}>
     <Text 
         value={proxyServer} 
         onChange={(e) => handleProxyChange(e, { name: "proxyServer", value: e.target.value })} 
@@ -279,7 +298,6 @@ const AddProxy = () => {
         value={proxyPort}
         onChange={(e) => handleProxyChange(e, { name: "proxyPort", value: e.target.value })} 
         type="number"
-        placeholder = "8080"
     />
     </ControlGroup>
     <ControlGroup labelWidth={WIDTH} label="Enable Authentication">


### PR DESCRIPTION
Closes #5

- Added proxy functionality to frontend
- Added proxy functionality to backend python scripts. api.py, hib_domainsearch.py
- updated deprecated  defaultFetchInit references to use getDefaultFetchInit() instead.
- updated restmap to pass session credentials through to api.py backend to assist with getting config values.
- updated inputs.conf.spec file to reflect new settings.
- updated build scripts to fix failed splunklib install, installs / upgrades wheel first.
- had to use --ignore-engines with yarn as i couldn't get it to build otherwise.


TODO:
- Proxy settings in frontend don't autofill on page refresh. didn't get to it. 
- actual testing. don't have a HIBP API i can use for testing.